### PR TITLE
Problem: mqtt won't compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,7 @@ nom = "^2.0"
 byteorder = "^0.5"
 slab = "^0.3"
 rotor = "^0.6"
-
-[dependencies.bytes]
-git = "https://github.com/carllerche/bytes"
+bytes = { git = "https://github.com/carllerche/bytes", rev = "53d1c78" }
 
 [dev-dependencies]
 env_logger = "^0.3"


### PR DESCRIPTION
The API surface of the `bytes` crates has changed significantly
and the revision used at the time was pinned.

Solution: pin bytes to the last known compatible revision